### PR TITLE
Checking for cancellation request after operation task is exits. This…

### DIFF
--- a/GameUtilities.Runtime/Classes/Public/Async/AsyncOperationHandle.cs
+++ b/GameUtilities.Runtime/Classes/Public/Async/AsyncOperationHandle.cs
@@ -42,6 +42,8 @@ namespace ADM87.GameUtilities.Async
                     try
                     {
                         await _operation(_cancellationTokenSource.Token);
+                        _cancellationTokenSource.Token.ThrowIfCancellationRequested();
+
                         Phase = EAsyncOperationPhase.Completed;
                         _completed?.Invoke();
                     }


### PR DESCRIPTION
… is to ensure the request is catch if the operation wasn't checking for the cancellation